### PR TITLE
FIX keep special code and replace desc by label on supplier proposal

### DIFF
--- a/class/subtotal.class.php
+++ b/class/subtotal.class.php
@@ -58,7 +58,11 @@ class TSubtotal {
 			/**
 			 * @var $object Propal Fournisseur
 			 */
-			else if($object->element=='supplier_proposal') $res = $object->addline($desc, 0,$qty,0,0,0,0,0,'HT',0,0,9,$rang, TSubtotal::$module_number, 0, 0, 0, $label);
+			else if($object->element=='supplier_proposal') {
+                /** @var SupplierProposal $object */
+                $object->special_code = TSubtotal::$module_number;
+                $res = $object->addline($label, 0, $qty, 0, 0, 0, 0, 0, 'HT', 0, 0, 9, $rang, TSubtotal::$module_number, 0, 0, 0, '');
+            }
 
 			/**
 			 * @var $object Commande
@@ -727,6 +731,8 @@ class TSubtotal {
 		        break;
 
 		    case 'supplier_proposal':
+                $object->special_code = self::$module_number;
+                if (empty($desc)) $desc = $label;
 		        $res = $object->updateline($rowid, $pu, $qty, $remise_percent, $txtva, $txlocaltax1, $txlocaltax2, $desc, $price_base_type, $info_bits, $special_code, $fk_parent_line, $skip_update_total, $fk_fournprice, $pa_ht, $label, $type, $array_options,'', $fk_unit);
 		        break;
 


### PR DESCRIPTION
FIX keep special code and replace desc by label on supplier proposal
- when you want to create an supplier order from a supplier proposal, special code is not set and you loose "subtotal" lines
- label was replaced by description when you add a subtotal line in supplier proposal (label not used in addline method)