### PR TITLE
FIX duplicate origin lines on create from proposal (PR #273)

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -3238,12 +3238,9 @@ class ActionsSubtotal
 
 	function printOriginObjectSubLine($parameters, &$object, &$action, $hookmanager)
 	{
-		global $conf,$langs,$user,$db,$bc, $restrictlist, $selectedLines;
+		global $conf, $restrictlist, $selectedLines;
 
 		$line = &$parameters['line'];
-		$i = &$parameters['i'];
-
-		$var = &$parameters['var'];
 
 		$contexts = explode(':',$parameters['context']);
 
@@ -3333,18 +3330,19 @@ class ActionsSubtotal
 					$object->tpl["sublabel"].= ' : <b>'.$total.'</b>';
 				}
 
+                $object->printOriginLine($line, '', $restrictlist, '/core/tpl', $selectedLines);
+
+                unset($object->tpl["sublabel"]);
+                unset($object->tpl['sub-td-style']);
+                unset($object->tpl['sub-tr-style']);
+                unset($object->tpl['sub-type']);
+                unset($object->tpl['subtotal']);
+
+                return 1;
 			}
-
-			$object->printOriginLine($line, '', $restrictlist, '/core/tpl', $selectedLines);
-
-			unset($object->tpl["sublabel"]);
-			unset($object->tpl['sub-td-style']);
-			unset($object->tpl['sub-tr-style']);
-			unset($object->tpl['sub-type']);
-			unset($object->tpl['subtotal']);
 		}
 
-        return 1;
+        return 0;
 	}
 
     /**


### PR DESCRIPTION
FIX duplicate origin lines on create from proposal
- when you create an invoice or order from a proposal you got duplicate lines if there are "Ouvrage" (or other external modules with product type "9") lines in proposal

![image](https://user-images.githubusercontent.com/45359511/177347132-c9731cb4-1ec5-49d2-81f7-f6db7d73d37f.png)
