### PR TITLE
FIX hide inner lines in supplier order document

### DIFF
--- a/class/actions_subtotal.class.php
+++ b/class/actions_subtotal.class.php
@@ -2129,7 +2129,7 @@ class ActionsSubtotal
 		}
 
 		$TContext	= explode(':', $parameters['context']);	// InfraS add
-		if (in_array('propalcard', $TContext) || in_array('ordercard', $TContext) || in_array('invoicecard', $TContext)) {	// InfraS add
+		if (in_array('propalcard', $TContext) || in_array('ordercard', $TContext) || in_array('invoicecard', $TContext) || in_array('supplier_proposalcard', $TContext) || in_array('ordersuppliercard', $TContext) || in_array('invoicesuppliercard', $TContext)) {	// InfraS add
 
 		$object->subtotalPdfModelInfo = new stdClass(); // see defineColumnFiel method in this class
 		$object->subtotalPdfModelInfo->cols = false;
@@ -2182,6 +2182,10 @@ class ActionsSubtotal
 
 			foreach($object->lines as $k=>&$line)
 			{
+                // to keep compatibility with supplier order and old versions (rowid was replaced with id in fetch lines method)
+                if ($line->id > 0) {
+                    $line->rowid = $line->id;
+                }
 
 				if($line->product_type==9 && $line->rowid>0)
 				{


### PR DESCRIPTION
FIX hide inner lines in supplier order document
- sur les commandes fournisseurs : 
![image](https://user-images.githubusercontent.com/45359511/211060647-3748d900-8e5b-43d2-8db1-ca463a4a8d32.png)

- avec les options avant génération : 
[ x]  Cacher le détail des ensembles
[ x] Cacher le prix et quantités des lignes des ensembles 

![image](https://user-images.githubusercontent.com/45359511/211060832-8ccc3a39-e13a-4d8c-af56-f728b8fa259d.png)


**Avant**
- on avait le montant sur la ligne de sous total est à zéro
![image](https://user-images.githubusercontent.com/45359511/211060944-080b8646-8e91-472a-aca5-08bfe8d3d0a1.png)

**Après**
- avec cette correction le montant sur le ligne de sous-total n'est plus à zéro
![image](https://user-images.githubusercontent.com/45359511/211061164-9c883c9f-23ac-40c5-8333-adff5ac2b24a.png)