### PR TITLE
FIX : group deletion would delete next group's title if the subtotal line had been deleted

### DIFF
--- a/class/subtotal.class.php
+++ b/class/subtotal.class.php
@@ -766,23 +766,22 @@ class TSubtotal {
 
 				if ( ($key_is_id && $line->id == $key_trad) || (!$key_is_id && $line->product_type == 9 && $line->qty == $level && (in_array($line->desc, $TTitle_search) || in_array($line->label, $TTitle_search) )))
 				{
-
 					if ($key_is_id) $level = $line->qty;
 
 					$add_line = true;
 					if ($withBlockLine) $TLine[] = $line;
 					continue;
 				}
-				elseif ($add_line && TSubtotal::isModSubtotalLine($line) && TSubtotal::getNiveau($line) == $level) // Si on tombe sur un sous-total, il faut que ce soit un du même niveau que le titre
+				elseif ($add_line && self::isModSubtotalLine($line) && self::getNiveau($line) == $level) // Si on tombe sur un sous-total, il faut que ce soit un du même niveau que le titre.
 				{
-
-					if ($withBlockLine) $TLine[] = $line;
+					if (self::isSubtotal($line)) {
+						if ($withBlockLine) $TLine[] = $line;
+					} // Si le sous-total a été supprimé, il ne faut pas premdre le titre de mêm niveau qui suit
 					break;
 				}
 
 				if ($add_line)
 				{
-
 					if (!$withBlockLine && (self::isTitle($line) || self::isSubtotal($line)) ) continue;
 					else $TLine[] = $line;
 				}


### PR DESCRIPTION
FIX : group deletion would delete next group's title if the subtotal line had been deleted

We have such an order:

![Capture d’écran_2024-03-11_15-31-33](https://github.com/SylvainLegrand/subtotal/assets/89838020/1eb6d936-97d2-45c5-85d2-a89f5f13f389)

To make this:
- we have created a group GROUPE 1
- we have added products
- we have deleted the subtotal line because we don't want the subtotal, we only want the title

Then, we delete the group 1

=> BUG : the title of group 2 is also deleted.

This PR fixes this behavior.
