### PR TITLE
FIX hook pdf generation on payment when calling out of cards

### DIFF
--- a/core/modules/modSubtotal.class.php
+++ b/core/modules/modSubtotal.class.php
@@ -130,6 +130,7 @@ class modSubtotal extends DolibarrModules
 				,'supplierorderlist'
 				,'supplierinvoicelist'
                 ,'cron'
+				,'pdfgeneration'
             ),
             // Set here all workflow context managed by module
             //'workflow' => array('order' => array('WORKFLOW_ORDER_AUTOCREATE_INVOICE')),


### PR DESCRIPTION
FIX hook pdf generation on payment when calling out of cards (#425)
- when you call generateDocument but you are not in a card, the hooks of this module are not reached and the PDF generated don't have special lines for subtotal lines (you got 0 in quantities ...)